### PR TITLE
Make options argument optional on initialization

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -8,6 +8,8 @@ var result = function (obj, prop) {
 
 
 function FormView(opts) {
+    opts = opts || {};
+
     this.el = opts.el;
     this.validCallback = opts.validCallback || this.validCallback || function () {};
     this.submitCallback = opts.submitCallback || this.submitCallback || function () {};


### PR DESCRIPTION
Code below will fail because we didn't pass an empty object on initialization, which will result in undefined variable on the first assignment `this.el = opts.el`.

``` js
var AwesomeFormView = FormView.extend({
    fields: [
        new SelectView({
            label: 'Pick a color!',
            name: 'color',
            value: 'blue',
            options: ['blue', 'orange', 'red']
        })
    ]
});

var awesomeFormView = new AwesomeFormView();
```
