### PR TITLE
Fix for removeField method

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -54,9 +54,12 @@ extend(FormView.prototype, BBEvents, {
     },
 
     removeField: function (name) {
-        var field = this.getField(name).remove();
-        delete this._fieldViews[name];
-        this._fieldViewsArray.splice(this._fieldViewsArray.indexOf(field), 1);
+        var field = this.getField(name);
+        if (field) {
+            field.remove();
+            delete this._fieldViews[name];
+            this._fieldViewsArray.splice(this._fieldViewsArray.indexOf(field), 1);
+        }
     },
 
     getField: function (name) {


### PR DESCRIPTION
I noticed that this doesn't work so Here is what I think the fix should be.

There were undefined variables being referenced so calling `removeField` would blow up immediately.
