### PR TITLE
Fixing bug in result() function

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -3,7 +3,7 @@ var extend = require('extend-object');
 
 var result = function (obj, prop) {
     if (typeof obj[prop] === 'function') return obj[prop]();
-    return prop;
+    return obj[prop];
 };
 
 


### PR DESCRIPTION
Currently it causes the result(this, 'fields') call to return 'fields' if the fields property is not a function.
