### PR TITLE
Allow `clean` option to be specified with `extend`

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -11,11 +11,11 @@ function FormView(opts) {
     this.el = opts.el;
     this.validCallback = opts.validCallback || this.validCallback || function () {};
     this.submitCallback = opts.submitCallback || this.submitCallback || function () {};
+    this.clean = opts.clean || this.clean || function (res) { return res; };
 
     if (opts.data) this.data = opts.data;
     if (opts.model) this.model = opts.model;
 
-    this.clean = opts.clean || function (res) { return res; };
     this.valid = false;
     this.preventDefault = opts.preventDefault === false ? false : true;
     this.autoAppend = opts.autoAppend === false ? false : true;
@@ -42,6 +42,7 @@ extend(FormView.prototype, BBEvents, {
     data: null,
     model: null,
     fields: null,
+    clean: null,
 
     addField: function (fieldView) {
         this._fieldViews[fieldView.name] = fieldView;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "url": "git://github.com/ampersandjs/ampersand-form-view"
   },
   "scripts": {
+    "validate": "jshint .",
     "start": "run-browser test/index.js",
     "test": "browserify test/index.js | tape-run | tap-spec"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "git://github.com/ampersandjs/ampersand-form-view"
   },
   "scripts": {
-    "validate": "jshint .",
+    "lint": "jshint .",
     "start": "run-browser test/index.js",
     "test": "browserify test/index.js | tape-run | tap-spec"
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -9,79 +9,186 @@ var AmpersandFormView = require('../ampersand-form-view');
 if (!Function.prototype.bind) Function.prototype.bind = require('function-bind');
 
 var Model = AmpersandModel.extend({
-    props: {
-        text: 'string',
-        textarea: 'string'
-    }
+	props: {
+		text: 'string',
+		textarea: 'string'
+	}
 });
 
 var getView = function () {
-    var FormView = AmpersandFormView.extend({
-        fields: function () {
-            return [
-                // TODO: add an AmpersandCheckboxView.
-                new AmpersandInputView({
-                    name: 'text',
-                    type: 'text',
-                    value: 'Original value'
-                }),
-                new AmpersandInputView({
-                    name: 'textarea',
-                    type: 'textarea',
-                    value: 'Original value'
-                })
-            ];
-        }
-    });
 
-    // Create a View with a nested FormView.
-    var View = AmpersandView.extend({
-        template: '<form data-hook="test-form"></form>',
-        render: function () {
-          this.renderWithTemplate();
-          this.form = new FormView({
-            el: this.queryByHook('test-form'),
-            model: this.model
-          });
-          this.registerSubview(this.form);
+	var FormView = AmpersandFormView.extend({
+		fields: function () {
+			return [
+				// TODO: add an AmpersandCheckboxView.
+				new AmpersandInputView({
+					name: 'text',
+					type: 'text',
+					value: 'Original value'
+				}),
+				new AmpersandInputView({
+					name: 'textarea',
+					type: 'textarea',
+					value: 'Original value'
+				})
+			];
+		}
+	});
 
-          return this;
-        }
-    });
+	// Create a View with a nested FormView.
+	var View = AmpersandView.extend({
+		template: '<form data-hook="test-form"></form>',
+		render: function () {
+			this.renderWithTemplate();
+			this.form = new FormView({
+				el: this.queryByHook('test-form'),
+				model: this.model
+			});
+			this.registerSubview(this.form);
 
-    var view = new View({
-        model: new Model()
-    });
+			return this;
+		}
+	});
 
-    return view.render();
+	var view = new View({
+		model: new Model()
+	});
+
+	return view.render();
+};
+
+var getViewWithFormClean = function () {
+
+	var FormView = AmpersandFormView.extend({
+		fields: function () {
+			return [
+				// TODO: add an AmpersandCheckboxView.
+				new AmpersandInputView({
+					name: 'text',
+					type: 'text',
+					value: 'Original value'
+				}),
+				new AmpersandInputView({
+					name: 'textarea',
+					type: 'textarea',
+					value: 'Original value'
+				})
+			];
+		},
+		clean: function(data) {
+			data.text = data.text.toUpperCase();
+			return data;
+		}
+	});
+
+	var View = AmpersandView.extend({
+		template: '<form data-hook="test-form"></form>',
+		render: function () {
+			this.renderWithTemplate();
+			this.form = new FormView({
+				el: this.queryByHook('test-form'),
+				model: this.model
+			});
+			this.registerSubview(this.form);
+
+			return this;
+		}
+	});
+
+	var view = new View({
+		model: new Model()
+	});
+
+	return view.render();
+};
+
+var getViewWithFormCleanOnInstance = function () {
+
+	var FormView = AmpersandFormView.extend({
+		fields: function () {
+			return [
+				// TODO: add an AmpersandCheckboxView.
+				new AmpersandInputView({
+					name: 'text',
+					type: 'text',
+					value: 'Original value'
+				}),
+				new AmpersandInputView({
+					name: 'textarea',
+					type: 'textarea',
+					value: 'Original value'
+				})
+			];
+		}
+	});
+
+	var View = AmpersandView.extend({
+		template: '<form data-hook="test-form"></form>',
+		render: function () {
+			this.renderWithTemplate();
+			this.form = new FormView({
+				el: this.queryByHook('test-form'),
+				model: this.model,
+				clean: function(data) {
+					data.text = data.text.toLowerCase();
+					return data;
+				}
+			});
+			this.registerSubview(this.form);
+
+			return this;
+		}
+	});
+
+	var view = new View({
+		model: new Model()
+	});
+
+	return view.render();
 };
 
 test('reset', function (t) {
-    var view = getView();
+	var view = getView();
 
-    view.form._fieldViewsArray.forEach(function (field) {
-        field.input.value = 'New value';
-    });
-    view.form.reset();
-    view.form._fieldViewsArray.forEach(function (field) {
-        var input = field.input;
-        t.equal(input.value, 'Original value', input.name + ' field value should be original value');
-    });
+	view.form._fieldViewsArray.forEach(function (field) {
+		field.input.value = 'New value';
+	});
+	view.form.reset();
+	view.form._fieldViewsArray.forEach(function (field) {
+		var input = field.input;
+		t.equal(input.value, 'Original value', input.name + ' field value should be original value');
+	});
 
-    t.end();
+	t.end();
 });
 
 test('clear', function (t) {
-    var view = getView();
+	var view = getView();
 
-    view.form._fieldViewsArray.forEach(function (field) {
-        field.input.value = 'New value';
-    });
-    view.form.clear();
-    view.form._fieldViewsArray.forEach(function (field) {
-        var input = field.input;
-        t.equal(input.value, '', input.name + ' field value should be empty');
-    });
+	view.form._fieldViewsArray.forEach(function (field) {
+		field.input.value = 'New value';
+	});
+	view.form.clear();
+	view.form._fieldViewsArray.forEach(function (field) {
+		var input = field.input;
+		t.equal(input.value, '', input.name + ' field value should be empty');
+	});
 
-    t.end();
+	t.end();
+});
+
+test('clean', function (t) {
+	var view = getViewWithFormClean();
+
+	var data = view.form.getData();
+	t.equal(data.text, 'ORIGINAL VALUE', 'the returned data should be transformed by the clean function');
+	t.end();
+});
+
+test('clean', function (t) {
+	var view = getViewWithFormCleanOnInstance();
+
+	var data = view.form.getData();
+	t.equal(data.text, 'original value', 'the returned data should be transformed by the clean function');
+	t.end();
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,8 +5,6 @@ var AmpersandInputView = require('ampersand-input-view');
 var AmpersandFormView = require('../ampersand-form-view');
 
 
-// Patch PhantomJS.
-if (!Function.prototype.bind) Function.prototype.bind = require('function-bind');
 
 var Model = AmpersandModel.extend({
 	props: {

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,8 +4,6 @@ var AmpersandView = require('ampersand-view');
 var AmpersandInputView = require('ampersand-input-view');
 var AmpersandFormView = require('../ampersand-form-view');
 
-
-
 var Model = AmpersandModel.extend({
 	props: {
 		text: 'string',

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,186 +5,79 @@ var AmpersandInputView = require('ampersand-input-view');
 var AmpersandFormView = require('../ampersand-form-view');
 
 var Model = AmpersandModel.extend({
-	props: {
-		text: 'string',
-		textarea: 'string'
-	}
+    props: {
+        text: 'string',
+        textarea: 'string'
+    }
 });
 
 var getView = function () {
+    var FormView = AmpersandFormView.extend({
+        fields: function () {
+            return [
+                // TODO: add an AmpersandCheckboxView.
+                new AmpersandInputView({
+                    name: 'text',
+                    type: 'text',
+                    value: 'Original value'
+                }),
+                new AmpersandInputView({
+                    name: 'textarea',
+                    type: 'textarea',
+                    value: 'Original value'
+                })
+            ];
+        }
+    });
 
-	var FormView = AmpersandFormView.extend({
-		fields: function () {
-			return [
-				// TODO: add an AmpersandCheckboxView.
-				new AmpersandInputView({
-					name: 'text',
-					type: 'text',
-					value: 'Original value'
-				}),
-				new AmpersandInputView({
-					name: 'textarea',
-					type: 'textarea',
-					value: 'Original value'
-				})
-			];
-		}
-	});
+    // Create a View with a nested FormView.
+    var View = AmpersandView.extend({
+        template: '<form data-hook="test-form"></form>',
+        render: function () {
+          this.renderWithTemplate();
+          this.form = new FormView({
+            el: this.queryByHook('test-form'),
+            model: this.model
+          });
+          this.registerSubview(this.form);
 
-	// Create a View with a nested FormView.
-	var View = AmpersandView.extend({
-		template: '<form data-hook="test-form"></form>',
-		render: function () {
-			this.renderWithTemplate();
-			this.form = new FormView({
-				el: this.queryByHook('test-form'),
-				model: this.model
-			});
-			this.registerSubview(this.form);
+          return this;
+        }
+    });
 
-			return this;
-		}
-	});
+    var view = new View({
+        model: new Model()
+    });
 
-	var view = new View({
-		model: new Model()
-	});
-
-	return view.render();
-};
-
-var getViewWithFormClean = function () {
-
-	var FormView = AmpersandFormView.extend({
-		fields: function () {
-			return [
-				// TODO: add an AmpersandCheckboxView.
-				new AmpersandInputView({
-					name: 'text',
-					type: 'text',
-					value: 'Original value'
-				}),
-				new AmpersandInputView({
-					name: 'textarea',
-					type: 'textarea',
-					value: 'Original value'
-				})
-			];
-		},
-		clean: function(data) {
-			data.text = data.text.toUpperCase();
-			return data;
-		}
-	});
-
-	var View = AmpersandView.extend({
-		template: '<form data-hook="test-form"></form>',
-		render: function () {
-			this.renderWithTemplate();
-			this.form = new FormView({
-				el: this.queryByHook('test-form'),
-				model: this.model
-			});
-			this.registerSubview(this.form);
-
-			return this;
-		}
-	});
-
-	var view = new View({
-		model: new Model()
-	});
-
-	return view.render();
-};
-
-var getViewWithFormCleanOnInstance = function () {
-
-	var FormView = AmpersandFormView.extend({
-		fields: function () {
-			return [
-				// TODO: add an AmpersandCheckboxView.
-				new AmpersandInputView({
-					name: 'text',
-					type: 'text',
-					value: 'Original value'
-				}),
-				new AmpersandInputView({
-					name: 'textarea',
-					type: 'textarea',
-					value: 'Original value'
-				})
-			];
-		}
-	});
-
-	var View = AmpersandView.extend({
-		template: '<form data-hook="test-form"></form>',
-		render: function () {
-			this.renderWithTemplate();
-			this.form = new FormView({
-				el: this.queryByHook('test-form'),
-				model: this.model,
-				clean: function(data) {
-					data.text = data.text.toLowerCase();
-					return data;
-				}
-			});
-			this.registerSubview(this.form);
-
-			return this;
-		}
-	});
-
-	var view = new View({
-		model: new Model()
-	});
-
-	return view.render();
+    return view.render();
 };
 
 test('reset', function (t) {
-	var view = getView();
+    var view = getView();
 
-	view.form._fieldViewsArray.forEach(function (field) {
-		field.input.value = 'New value';
-	});
-	view.form.reset();
-	view.form._fieldViewsArray.forEach(function (field) {
-		var input = field.input;
-		t.equal(input.value, 'Original value', input.name + ' field value should be original value');
-	});
+    view.form._fieldViewsArray.forEach(function (field) {
+        field.input.value = 'New value';
+    });
+    view.form.reset();
+    view.form._fieldViewsArray.forEach(function (field) {
+        var input = field.input;
+        t.equal(input.value, 'Original value', input.name + ' field value should be original value');
+    });
 
-	t.end();
+    t.end();
 });
 
 test('clear', function (t) {
-	var view = getView();
+    var view = getView();
 
-	view.form._fieldViewsArray.forEach(function (field) {
-		field.input.value = 'New value';
-	});
-	view.form.clear();
-	view.form._fieldViewsArray.forEach(function (field) {
-		var input = field.input;
-		t.equal(input.value, '', input.name + ' field value should be empty');
-	});
+    view.form._fieldViewsArray.forEach(function (field) {
+        field.input.value = 'New value';
+    });
+    view.form.clear();
+    view.form._fieldViewsArray.forEach(function (field) {
+        var input = field.input;
+        t.equal(input.value, '', input.name + ' field value should be empty');
+    });
 
-	t.end();
-});
-
-test('clean', function (t) {
-	var view = getViewWithFormClean();
-
-	var data = view.form.getData();
-	t.equal(data.text, 'ORIGINAL VALUE', 'the returned data should be transformed by the clean function');
-	t.end();
-});
-
-test('clean', function (t) {
-	var view = getViewWithFormCleanOnInstance();
-
-	var data = view.form.getData();
-	t.equal(data.text, 'original value', 'the returned data should be transformed by the clean function');
-	t.end();
+    t.end();
 });

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -51,7 +51,22 @@ test('submitCallback', function(t) {
 })
 
 test('beforeSubmit', function(t) {
-  t.end();
+  var field = new FakeField({
+    name: 'field',
+    beforeSubmit: function() {
+      t.equal(this, field, 'should call beforeSubmit on the field');
+      this.value = 42;
+    }
+  })
+  var form = new FormView({
+    fields: [ field ],
+    submitCallback: function(data) {
+      t.equal(data.field, 42, 'should call submitCallback after beforeSubmit on the fields');
+      t.end();
+    }
+  })
+  form.render();
+  form.handleSubmit(document.createEvent('Event'))
 })
 
 test('validCallback', function(t) {
@@ -73,4 +88,3 @@ test('validCallback', function(t) {
 test('clean', function(t) {
   t.end();
 })
-

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -76,7 +76,7 @@ test('validCallback', function(t) {
     fields: [ field ],
     validCallback: (function(valid) {
       if (--count <= 0) {
-        t.equal(valid, field.valid, 'should call validCallback');
+        t.equal(valid, field.valid, 'should call validCallback twice');
         t.end();
       }
     })
@@ -85,6 +85,22 @@ test('validCallback', function(t) {
   field.setValid(true);
 })
 
+test('autoappend', function(t) {
+  t.end();
+})
+
 test('clean', function(t) {
+  var field = new FakeField({ name: 'some_field', value: '27' })
+  var form = new FormView({
+    fields: [ field ],
+    clean: function(data) {
+      t.equal(data.some_field, field.value, 'data should have the raw value from the field')
+      data.some_field = Number(data.some_field);
+      return data;
+    },
+  })
+  var data = form.getData()
+  t.equal(data.some_field, Number(field.value), 'getData should return cleaned data');
+  t.plan(2);
   t.end();
 })

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var FormView = require('../ampersand-form-view');
 
 function FakeField(opts) {
-  opts = opts || {}
+  opts = opts || {};
 
   this.valid = opts.valid === false ? false : true;
   this.name = opts.name || 'fake-field';
@@ -29,14 +29,14 @@ FakeField.prototype = {
 
   render: function() {
     if (!this.el) {
-      this.el = document.createElement('div')
+      this.el = document.createElement('div');
     }
     return this;
   },
 
   remove: function() {
   }
-}
+};
 
 test('submitCallback', function(t) {
   var form = new FormView({
@@ -48,7 +48,7 @@ test('submitCallback', function(t) {
   form.render();
 
   form.handleSubmit(document.createEvent('Event'));
-})
+});
 
 test('beforeSubmit', function(t) {
   var field = new FakeField({
@@ -57,17 +57,17 @@ test('beforeSubmit', function(t) {
       t.equal(this, field, 'should call beforeSubmit on the field');
       this.value = 42;
     }
-  })
+  });
   var form = new FormView({
     fields: [ field ],
     submitCallback: function(data) {
       t.equal(data.field, 42, 'should call submitCallback after beforeSubmit on the fields');
       t.end();
     }
-  })
+  });
   form.render();
-  form.handleSubmit(document.createEvent('Event'))
-})
+  form.handleSubmit(document.createEvent('Event'));
+});
 
 test('validCallback', function(t) {
   var field = new FakeField({valid: false});
@@ -83,24 +83,24 @@ test('validCallback', function(t) {
   });
   form.render();
   field.setValid(true);
-})
+});
 
 test('autoappend', function(t) {
   t.end();
-})
+});
 
 test('clean', function(t) {
-  var field = new FakeField({ name: 'some_field', value: '27' })
+  var field = new FakeField({ name: 'some_field', value: '27' });
   var form = new FormView({
     fields: [ field ],
     clean: function(data) {
-      t.equal(data.some_field, field.value, 'data should have the raw value from the field')
+      t.equal(data.some_field, field.value, 'data should have the raw value from the field');
       data.some_field = Number(data.some_field);
       return data;
     },
-  })
-  var data = form.getData()
+  });
+  var data = form.getData();
   t.equal(data.some_field, Number(field.value), 'getData should return cleaned data');
   t.plan(2);
   t.end();
-})
+});

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -104,3 +104,24 @@ test('clean', function(t) {
   t.plan(2);
   t.end();
 });
+
+test('clean', function(t) {
+	var field = new FakeField({
+		name: 'some_field',
+		value: '27'
+	});
+	var FormViewExtendedWithClean = FormView.extend({
+		clean: function(data) {
+			t.equal(data.some_field, field.value, 'data should have the raw value from the field');
+			data.some_field = Number(data.some_field);
+			return data;
+		}
+	});
+	var form = new FormViewExtendedWithClean({
+		fields: [ field ]
+	});
+	var data = form.getData();
+	t.equal(data.some_field, Number(field.value), 'getData should return cleaned data');
+	t.end();
+});
+

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -1,0 +1,76 @@
+var test = require('tape');
+var FormView = require('../ampersand-form-view');
+
+function FakeField(opts) {
+  opts = opts || {}
+
+  this.valid = opts.valid === false ? false : true;
+  this.name = opts.name || 'fake-field';
+  this.value = opts.value || 'fake-value';
+  this.parent = opts.parent || null;
+  this.beforeSubmit = opts.beforeSubmit || function() {};
+}
+FakeField.prototype = {
+  setValue: function(value) {
+    this.value = value;
+    this.updateParent();
+  },
+
+  setValid: function(valid) {
+    this.valid = valid;
+    this.updateParent();
+  },
+
+  updateParent: function() {
+    if (this.parent) {
+      this.parent.update(this);
+    }
+  },
+
+  render: function() {
+    if (!this.el) {
+      this.el = document.createElement('div')
+    }
+    return this;
+  },
+
+  remove: function() {
+  }
+}
+
+test('submitCallback', function(t) {
+  var form = new FormView({
+    submitCallback: function(data) {
+      t.notEqual(data, undefined, 'should call submitCallback with data');
+      t.end();
+    }
+  });
+  form.render();
+
+  form.handleSubmit(document.createEvent('Event'));
+})
+
+test('beforeSubmit', function(t) {
+  t.end();
+})
+
+test('validCallback', function(t) {
+  var field = new FakeField({valid: false});
+  var count = 2;
+  var form = new FormView({
+    fields: [ field ],
+    validCallback: (function(valid) {
+      if (--count <= 0) {
+        t.equal(valid, field.valid, 'should call validCallback');
+        t.end();
+      }
+    })
+  });
+  form.render();
+  field.setValid(true);
+})
+
+test('clean', function(t) {
+  t.end();
+})
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,5 @@
+// Patch PhantomJS.
+if (!Function.prototype.bind) Function.prototype.bind = require('function-bind');
+
 require('./basic');
+require('./callbacks');


### PR DESCRIPTION
Previously, `clean` could only be set when creating an instance of `ampersand-form-view`, not when extending the base view.