### PR TITLE
Permit No AutoRendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.log
+debug.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ That form can be given an array of field views.
 
 These fields are also <a href="http://ampersandjs.com/learn/view-conventions">views</a> but just follow a few more conventions in order to be able to work with a our form view.
 
-Those rules are as follows: 
+Those rules are as follows:
 
 - It maintains a `value` property that is the current value of the field.
 - It should also store a `value` property if passed in as part of the config/options object when the view is created.
@@ -32,7 +32,7 @@ npm install ampersand-form-view
 Here's how you might draw a form view as a subview.
 
 ```javascript
-// we'll just use an ampersand-view here as an 
+// we'll just use an ampersand-view here as an
 // example parent view
 var View = require('ampersand-view');
 var FormView = require('ampersand-form-view');
@@ -63,7 +63,7 @@ var AwesomeFormView = View.extend({
             // the rules described above. I'm using an input-view
             // here, but again, *this could be anything* you would
             // pass it whatever config items needed to instantiate
-            // the field view you made. 
+            // the field view you made.
             fields: [
                 new InputView({
                     name: 'client_name',
@@ -94,9 +94,10 @@ awesomeFormView.render();
 
 ## FormView Options `FormView.extend(options)`
 Standard <a href="http://ampersandjs.com/learn/view-conventions">view conventions</a> apply, with the following options added:
-
+* `autoRender` : boolean (default: true)
+    * Render the form immediately on construction.
 * `autoAppend` : boolean (default: true)
-    * Adds new nodes for all fields defined in the `fields` array.  Use `autoAppend: false` in conjuction with `el: yourElement` in order to use your own form layout
+    * Adds new nodes for all fields defined in the `fields` array.  Use `autoAppend: false` in conjuction with `el: yourElement` in order to use your own form layout.
 * `fields` : array
     * Array of `FieldView`s.  If `autoAppend` is true, nodes defined by the view are built and appended to the end of the FormView.
 * `submitCallback` : function
@@ -119,6 +120,7 @@ Calls clear on all fields in the form that have the method. Intended to be used 
 
 ## Changelog
 
+- 3.0.0 - Initialize prior to render, and permit `autoRender: false`
 - 2.2.3 - Adding `reset`. Starting in on building API reference.
 
 ## credits

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -142,21 +142,20 @@ extend(FormView.prototype, BBEvents, {
 
     render: function () {
         if (this.rendered) return;
-        if (this.template) this.renderWithTemplate();
         if (!this.el) {
             this.el = document.createElement('form');
         }
         if (this.autoAppend) {
             this.fieldContainerEl = this.el.querySelector('[data-hook~=field-container]') || this.el;
         }
-        this._fieldViewsArray.forEach(function(fV) { this.renderField(fV, true); }, this);
+        this._fieldViewsArray.forEach(function (fV) { this.renderField(fV, true); }, this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.el.addEventListener('submit', this.handleSubmit, false);
         this.checkValid(true);
         this.rendered = true;
     },
 
-    renderField: function(fieldView, renderInProgress) {
+    renderField: function (fieldView, renderInProgress) {
         if (fieldView.rendered || !this.fieldContainerEl) { return this; }
         if (!this.rendered && !renderInProgress) { return this; }
         fieldView.parent = this;

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -7,8 +7,6 @@ var result = require('amp-result');
 
 function FormView(opts) {
     opts = opts || {};
-    opts.autoRender = opts.autoRender !== undefined ? opts.autoRender : true;
-
     this.el = opts.el;
     this.validCallback = opts.validCallback || this.validCallback || function () {};
     this.submitCallback = opts.submitCallback || this.submitCallback || function () {};
@@ -20,6 +18,7 @@ function FormView(opts) {
     this.valid = false;
     this.preventDefault = opts.preventDefault === false ? false : true;
     this.autoAppend = opts.autoAppend === false ? false : true;
+    opts.autoRender = opts.autoRender === false ? false : true;
 
     // storage for our fields
     this._fieldViews = {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-form-view",
   "description": "Completely customizable form lib for bulletproof clientside forms.",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browserify": {
     "transform": [
@@ -47,6 +47,7 @@
   "scripts": {
     "lint": "jshint .",
     "start": "run-browser test/index.js",
-    "test": "browserify test/index.js | tape-run | tap-spec"
+    "test": "browserify test/index.js | tape-run | tap-spec",
+    "debug": "browserify test/index.js -o debug.js"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,7 +11,10 @@ var Model = AmpersandModel.extend({
     }
 });
 
-var getView = function () {
+var getView = function (opts) {
+    var formOpts;
+    opts = opts || {};
+    formOpts = opts.form || {};
     var FormView = AmpersandFormView.extend({
         fields: function () {
             return [
@@ -34,14 +37,14 @@ var getView = function () {
     var View = AmpersandView.extend({
         template: '<form data-hook="test-form"></form>',
         render: function () {
-          this.renderWithTemplate();
-          this.form = new FormView({
-            el: this.queryByHook('test-form'),
-            model: this.model
-          });
-          this.registerSubview(this.form);
-
-          return this;
+            this.renderWithTemplate();
+            this.form = new FormView({
+                autoRender: formOpts.autoRender,
+                el: this.queryByHook('test-form'),
+                model: this.model
+            });
+            this.registerSubview(this.form);
+            return this;
         }
     });
 
@@ -79,5 +82,13 @@ test('clear', function (t) {
         t.equal(input.value, '', input.name + ' field value should be empty');
     });
 
+    t.end();
+});
+
+test('autoRender', function (t) {
+    var view = getView({ form: { autoRender: false } });
+    var form = view.form;
+    t.ok(!form.rendered, 'form did not autoRender');
+    t.ok(!form._fieldViewsArray[0].rendered, 'form field did not autoRender');
     t.end();
 });

--- a/testem.json
+++ b/testem.json
@@ -1,7 +1,7 @@
 {
     "framework": "tap",
     "src_files": [
-        "ampersand-forum-view.js",
+        "ampersand-form-view.js",
         "test/*.js"
     ],
     "serve_files": [


### PR DESCRIPTION
# problem statement
ampersand-form-view auto-renders.  it shouldn't have to, as it's not always desirable. 

# solution
permit `autoRender: false` as with other views.  ampersand-form-view generally renders then initializes too, which is seemingly backwards against the status quo.  swapping this order introduces breaking changes, hence the semver bump.

suffixing `?w=1` to the URL string may help review to filter out whitespace