### PR TITLE
&-view conversion and closes #28

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "browser": true,
   "latedef": true,
   "quotmark": true,
   "undef": true,
@@ -8,6 +9,7 @@
     "require",
     "setTimeout",
     "document",
-    "module"
+    "module",
+    "console"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ var AwesomeFormView = View.extend({
     render: function () {
         this.renderWithTemplate();
         this.form = new FormView({
+            autoRender: true,
             el: this.queryByHook('app-edit-form'),
             submitCallback: function (obj) {
                 console.log('form submitted! Your data:', obj);
@@ -82,7 +83,15 @@ var AwesomeFormView = View.extend({
                         }
                     ]
                 })
-            ]
+            ],
+            // optional initial form values specified by
+            // {"field-name": "value"} pairs. Overwrites default
+            // `value`s provided in your FieldView constructors, only
+            // after the form is rendered. You can set form values
+            // in bulk after the form is rendered using setValues().
+            values: {
+                client_name: 'overrides "hello" from above'
+            }
         });
 
         // registering the form view as a subview ensures that
@@ -114,6 +123,43 @@ Standard <a href="http://ampersandjs.com/learn/view-conventions">view convention
 =======
 ## API Reference
 
+### setValue `formView.setValue(name, value)`
+
+Sets the provided value on the field matching the provided name.  Throws when invalid field name specified.
+
+
+### getValue `formView.setValue(name)`
+
+Gets the value from the associated field matching the provided name.  Throws when invalid field name specified.
+
+### setValues `formView.setValues([values])`
+
+For each key corresponding to a field's `name` found in `values`, the corresponding `value` will be set onto the FieldView.  Executes when the the formView is **rendered**.
+
+```js
+myForm = new FormView({
+    fields: function() {
+        return [
+            new CheckboxView({
+                name: 'startsTrue',
+                value: true
+            }),
+            new CheckboxView({
+                name: 'startsFalse',
+                value: false
+            }),
+        ];
+    }
+});
+myForm.render();
+
+// bulk update form values
+myForm.setValues({
+    startsTrue: true,  //=> no change
+    startsFalse: true  //=> becomes true
+});
+```
+
 ### reset `formView.reset()`
 
 Calls reset on all fields in the form that have the method. Intended to be used to set form back to original state.
@@ -124,6 +170,7 @@ Calls clear on all fields in the form that have the method. Intended to be used 
 
 ## Changelog
 
+- 4.0.0 - Extend `ampersand-view` to add state, adds `setValues()`, `setValue()`, & `getValue()`.  Change to not render() during construction by default.
 - 3.0.0 - Initialize prior to render, and permit `autoRender: false`
 - 2.2.3 - Adding `reset`. Starting in on building API reference.
 

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -181,7 +181,6 @@ module.exports = View.extend({
 
     renderField: function (fieldView, renderInProgress) {
         if (!this.rendered && !renderInProgress) return this;
-        if (fieldView.rendered) return this;
         fieldView.parent = this;
         fieldView.render();
         if (this.autoAppend) this.fieldContainerEl.appendChild(fieldView.el);

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -66,10 +66,7 @@ module.exports = View.extend({
     },
 
     removeField: function (name, strict) {
-        var field = this.getField(name);
-        if (strict && !field) {
-            throw new ReferenceError('field name  "' + name + '" not found');
-        }
+        var field = this.getField(name, strict);
         if (field) {
             field.remove();
             delete this._fieldViews[name];
@@ -77,8 +74,12 @@ module.exports = View.extend({
         }
     },
 
-    getField: function (name) {
-        return this._fieldViews[name];
+    getField: function (name, strict) {
+        var field = this._fieldViews[name];
+        if (!field && strict) {
+            throw new ReferenceError('field name  "' + name + '" not found');
+        }
+        return field;
     },
 
     setValid: function (now, forceFire) {
@@ -90,14 +91,9 @@ module.exports = View.extend({
     },
 
     setValues: function (data) {
-        var value, field;
         for (var name in data) {
             if (data.hasOwnProperty(name)) {
-                field = this.getField(name);
-                if (field && field.setValue) {
-                    value = data[name];
-                    field.setValue(value);
-                }
+                this.setValue(name, data[name]);
             }
         }
     },
@@ -209,6 +205,7 @@ module.exports = View.extend({
 
     // deprecated
     getData: function() {
+        console.warn('deprecation warning: ampersand-form-view `.getData()` replaced by `.data`');
         return this.data;
     }
 

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -5,14 +5,6 @@ var result = require('lodash.result');
 var noop = function(){};
 
 module.exports = View.extend({
-    props: {
-        'model': 'state',
-        'rendered': {
-            type: 'boolean',
-            required: true,
-            default: false
-        }
-    },
     derived: {
         data: {
             fn: function () {

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -181,7 +181,6 @@ module.exports = View.extend({
         this.handleSubmit = this.handleSubmit.bind(this);
         this.el.addEventListener('submit', this.handleSubmit, false);
         this.checkValid(true);
-        this.rendered = true;
     },
 
     renderField: function (fieldView, renderInProgress) {

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -16,9 +16,9 @@ module.exports = View.extend({
                     }
                 }
                 return this.clean(res);
-            }
-        },
-        cache: false
+            },
+            cache: false
+        }
     },
 
     initialize: function(opts) {

--- a/package.json
+++ b/package.json
@@ -15,15 +15,14 @@
     "url": "https://github.com/ampersandjs/ampersand-form-view/issues"
   },
   "dependencies": {
-    "ampersand-class-extend": "^1.0.2",
-    "ampersand-events": "^1.1.1",
     "ampersand-version": "^1.0.0",
-    "lodash.assign": "^3.0.0",
+    "ampersand-view": "^7.3.0",
     "lodash.isfunction": "^3.0.2",
     "lodash.result": "^3.0.0"
   },
   "devDependencies": {
     "ampersand-input-view": "^3.1.0",
+    "ampersand-checkbox-view": "*",
     "ampersand-model": "^4.0.3",
     "ampersand-view": "^7.2.0",
     "browserify": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "ampersand-version": "^1.0.0",
-    "ampersand-view": "^7.3.0",
+    "ampersand-view": "^8.0.0",
     "lodash.isfunction": "^3.0.2",
     "lodash.result": "^3.0.0"
   },
@@ -24,7 +24,6 @@
     "ampersand-input-view": "^3.1.0",
     "ampersand-checkbox-view": "*",
     "ampersand-model": "^4.0.3",
-    "ampersand-view": "^7.2.0",
     "browserify": "^7.0.0",
     "function-bind": "^1.0.2",
     "jshint": "^2.6.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@ var test = require('tape').test;
 var AmpersandModel = require('ampersand-model');
 var AmpersandView = require('ampersand-view');
 var AmpersandInputView = require('ampersand-input-view');
+var AmpersandCheckboxView = require('ampersand-checkbox-view');
 var AmpersandFormView = require('../ampersand-form-view');
 
 var Model = AmpersandModel.extend({
@@ -11,6 +12,10 @@ var Model = AmpersandModel.extend({
     }
 });
 
+var isCheckbox = function(el) {
+    return el.type === 'checkbox';
+};
+
 var getView = function (opts) {
     var formOpts;
     opts = opts || {};
@@ -18,7 +23,10 @@ var getView = function (opts) {
     var FormView = AmpersandFormView.extend({
         fields: function () {
             return [
-                // TODO: add an AmpersandCheckboxView.
+                new AmpersandCheckboxView({
+                    name: 'check',
+                    value: true
+                }),
                 new AmpersandInputView({
                     name: 'text',
                     type: 'text',
@@ -41,7 +49,10 @@ var getView = function (opts) {
             this.form = new FormView({
                 autoRender: formOpts.autoRender,
                 el: this.queryByHook('test-form'),
-                model: this.model
+                model: this.model,
+                values: {
+                    text: 'Overriden value'
+                }
             });
             this.registerSubview(this.form);
             return this;
@@ -56,7 +67,7 @@ var getView = function (opts) {
 };
 
 test('reset', function (t) {
-    var view = getView();
+    var view = getView({ form: { autoRender: true } });
 
     view.form._fieldViewsArray.forEach(function (field) {
         field.input.value = 'New value';
@@ -64,6 +75,9 @@ test('reset', function (t) {
     view.form.reset();
     view.form._fieldViewsArray.forEach(function (field) {
         var input = field.input;
+        if (isCheckbox(input)) {
+            return;
+        }
         t.equal(input.value, 'Original value', input.name + ' field value should be original value');
     });
 
@@ -71,15 +85,24 @@ test('reset', function (t) {
 });
 
 test('clear', function (t) {
-    var view = getView();
+    var view = getView({ form: { autoRender: true } });
 
     view.form._fieldViewsArray.forEach(function (field) {
-        field.input.value = 'New value';
+        if (isCheckbox(field.input)) {
+            field.setValue(true);
+        } else {
+            field.setValue('New value');
+        }
+
     });
     view.form.clear();
     view.form._fieldViewsArray.forEach(function (field) {
         var input = field.input;
-        t.equal(input.value, '', input.name + ' field value should be empty');
+        if (isCheckbox(input)) {
+            t.equal(field.value, false, input.name + ' field value should be unchecked');
+        } else {
+            t.equal(field.value, '', input.name + ' field value should be empty');
+        }
     });
 
     t.end();
@@ -92,3 +115,49 @@ test('autoRender', function (t) {
     t.ok(!form._fieldViewsArray[0].rendered, 'form field did not autoRender');
     t.end();
 });
+
+test('setValues', function(t) {
+    var view = getView({ form: { autoRender: true }});
+    var form = view.form;
+    var checkField = form.getField('check');
+    var newCheckValue = !checkField.value;
+    var textField = form.getField('text');
+    var newTextValue = 'newTextValue';
+
+    t.equal(textField.value, 'Overriden value', 'setValues() updates fields on construction');
+
+    form.setValues({
+        check: newCheckValue,
+        text: newTextValue
+    });
+
+    t.equal(checkField.value, newCheckValue, 'setValues() updates field [input type="checkbox"]');
+    t.equal(textField.value, newTextValue, 'setValues() updates field [input type="text"]');
+    t.end();
+});
+
+test('field value setter/getter', function(t) {
+    var view = getView({ form: { autoRender: true }});
+
+    t.throws(
+        function() { view.form.getValue('invalidField'); },
+        'getValue() errors when no field present'
+    );
+    t.throws(
+        function() { view.form.setValue('invalidField', 1); },
+        'setValue() errors when no field present'
+    );
+
+    t.equal(view.form.getValue('textarea'), 'Original value', 'getValue() extracts value from provided field');
+    view.form.setValue('textarea', 'newValue');
+    t.equal(view.form.getValue('textarea'), 'newValue', 'setValue() sets value on provided field');
+    t.end();
+});
+
+test('deprecated', function(t) {
+    var view = getView({ form: { autoRender: true }});
+    var data = view.form.getData();
+    t.equal(data, view.form.data, '(deprecated) .getData proxies .data');
+    t.end();
+});
+

--- a/test/basic.js
+++ b/test/basic.js
@@ -153,11 +153,3 @@ test('field value setter/getter', function(t) {
     t.equal(view.form.getValue('textarea'), 'newValue', 'setValue() sets value on provided field');
     t.end();
 });
-
-test('deprecated', function(t) {
-    var view = getView({ form: { autoRender: true }});
-    var data = view.form.getData();
-    t.equal(data, view.form.data, '(deprecated) .getData proxies .data');
-    t.end();
-});
-

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -2,107 +2,90 @@ var test = require('tape');
 var FormView = require('../ampersand-form-view');
 
 function FakeField(opts) {
-  opts = opts || {};
+    opts = opts || {};
 
-  this.valid = opts.valid === false ? false : true;
-  this.name = opts.name || 'fake-field';
-  this.value = opts.value || 'fake-value';
-  this.parent = opts.parent || null;
-  this.beforeSubmit = opts.beforeSubmit || function() {};
+    this.valid = opts.valid === false ? false : true;
+    this.name = opts.name || 'fake-field';
+    this.value = opts.value || 'fake-value';
+    this.parent = opts.parent || null;
+    this.beforeSubmit = opts.beforeSubmit || function() {};
 }
 FakeField.prototype = {
-  setValue: function(value) {
-    this.value = value;
-    this.updateParent();
-  },
+    setValue: function(value) {
+        this.value = value;
+        this.updateParent();
+    },
 
-  setValid: function(valid) {
-    this.valid = valid;
-    this.updateParent();
-  },
+    setValid: function(valid) {
+        this.valid = valid;
+        this.updateParent();
+    },
 
-  updateParent: function() {
-    if (this.parent) {
-      this.parent.update(this);
+    updateParent: function() {
+        if (this.parent) {
+            this.parent.update(this);
+        }
+    },
+
+    render: function() {
+        if (!this.el) {
+            this.el = document.createElement('div');
+        }
+        return this;
+    },
+
+    remove: function() {
     }
-  },
-
-  render: function() {
-    if (!this.el) {
-      this.el = document.createElement('div');
-    }
-    return this;
-  },
-
-  remove: function() {
-  }
 };
 
 test('submitCallback', function(t) {
-  var form = new FormView({
-    submitCallback: function(data) {
-      t.notEqual(data, undefined, 'should call submitCallback with data');
-      t.end();
-    }
-  });
-  form.render();
-
-  form.handleSubmit(document.createEvent('Event'));
+    var form = new FormView({
+        submitCallback: function(data) {
+            t.notEqual(data, undefined, 'should call submitCallback with data');
+            t.end();
+        }
+    });
+    form.render();
+    form.handleSubmit(document.createEvent('Event'));
 });
 
 test('beforeSubmit', function(t) {
-  var field = new FakeField({
-    name: 'field',
-    beforeSubmit: function() {
-      t.equal(this, field, 'should call beforeSubmit on the field');
-      this.value = 42;
-    }
-  });
-  var form = new FormView({
-    fields: [ field ],
-    submitCallback: function(data) {
-      t.equal(data.field, 42, 'should call submitCallback after beforeSubmit on the fields');
-      t.end();
-    }
-  });
-  form.render();
-  form.handleSubmit(document.createEvent('Event'));
+    var field = new FakeField({
+        name: 'field',
+        beforeSubmit: function() {
+            t.equal(this, field, 'should call beforeSubmit on the field');
+            this.value = 42;
+        }
+    });
+    var form = new FormView({
+        fields: [ field ],
+        submitCallback: function(data) {
+            t.equal(data.field, 42, 'should call submitCallback after beforeSubmit on the fields');
+            t.end();
+        }
+    });
+    form.render();
+    form.handleSubmit(document.createEvent('Event'));
 });
 
 test('validCallback', function(t) {
-  var field = new FakeField({valid: false});
-  var count = 2;
-  var form = new FormView({
-    fields: [ field ],
-    validCallback: (function(valid) {
-      if (--count <= 0) {
-        t.equal(valid, field.valid, 'should call validCallback twice');
-        t.end();
-      }
-    })
-  });
-  form.render();
-  field.setValid(true);
+    var field = new FakeField({valid: false});
+    var count = 2;
+    var form = new FormView({
+        fields: [ field ],
+        validCallback: (function(valid) {
+            if (--count <= 0) {
+                t.equal(valid, field.valid, 'should call validCallback twice');
+                t.end();
+            }
+        })
+    });
+    form.render();
+    field.setValid(true);
 });
 
 test('autoappend', function(t) {
-  t.end();
-});
-
-test('clean', function(t) {
-  var field = new FakeField({ name: 'some_field', value: '27' });
-  var form = new FormView({
-    fields: [ field ],
-    clean: function(data) {
-      t.equal(data.some_field, field.value, 'data should have the raw value from the field');
-      data.some_field = Number(data.some_field);
-      return data;
-    },
-  });
-  var data = form.getData();
-  t.equal(data.some_field, Number(field.value), 'getData should return cleaned data');
-  t.plan(2);
-  t.end();
+    t.end();
 });
 
 test('clean', function(t) {
@@ -120,7 +103,7 @@ test('clean', function(t) {
 	var form = new FormViewExtendedWithClean({
 		fields: [ field ]
 	});
-	var data = form.getData();
-	t.equal(data.some_field, Number(field.value), 'getData should return cleaned data');
+	var data = form.data;
+	t.equal(data.some_field, Number(field.value), 'data should return cleaned data');
 	t.end();
 });


### PR DESCRIPTION
# problem statements
* formView is doesn't have `State`.  various requests have been made by the community to support this (including myself)
* support #28 (yeya!)
* `clean` has a fully duplicated/copied test
* mixed spacing in callbacks.js
* ampersand-checkbox-view not included in test suite, but has annotations to be included

# solutions
* convert module to extend &-view, enabling &-state within
    * move `getData()` to simple derived `data` property. leave `getData()` behind for deprecated support
* add all methods from #28, and add a handful of tests
* update README.md :smile:, always
* support setting predefined values on construction, similar to the request in #28
* update callbacks.js to 4sp, like the rest of the repo files
* add ampersand-checkbox-view to test suite

**dependent on https://github.com/AmpersandJS/ampersand-checkbox-view/pull/7 closing** as the tests expect ampersand-checkbox-view not to `render()` on construction per https://github.com/AmpersandJS/ampersand-form-view/issues/41