### PR TITLE
fix form submission

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -6,6 +6,10 @@ var noop = function(){};
 
 module.exports = View.extend({
 
+    events: {
+        'submit': 'handleSubmit'
+    },
+
     derived: {
         data: {
             fn: function () {
@@ -116,7 +120,6 @@ module.exports = View.extend({
     },
 
     remove: function () {
-        this.el.removeEventListener('submit', this.handleSubmit, false);
         this._fieldViewsArray.forEach(function (field) {
             field.remove();
         });
@@ -175,7 +178,6 @@ module.exports = View.extend({
             delete this._startingValues;
         }
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.el.addEventListener('submit', this.handleSubmit, false);
         this.checkValid(true);
     },
 


### PR DESCRIPTION
5.0.0 broke `submit` for me. It would always reload the entire page.
Since this module now extends &-view, I figured we could rely on its
event handling capabilities. This fixes the regression.