### PR TITLE
thisArg in native array methods

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -41,7 +41,7 @@ module.exports = View.extend({
         this._fieldViewsArray = [];
 
         // add all our fields
-        (result(opts, 'fields') || result(this, 'fields') || []).forEach(this.addField.bind(this));
+        (result(opts, 'fields') || result(this, 'fields') || []).forEach(this.addField, this);
 
         if (opts.autoRender) {
             this.autoRender = opts.autoRender;
@@ -164,7 +164,7 @@ module.exports = View.extend({
         }
         this._fieldViewsArray.forEach(function renderEachField(fV) {
             this.renderField(fV, true);
-        }.bind(this));
+        }, this);
         if (this._startingValues) {
             // setValues is ideally executed at initialize, with no persistent
             // memory consumption inside ampersand-form-view, however, some


### PR DESCRIPTION
Instead of binding the function explicitly with `bind`, pass in `this` as the second argument of the `forEach` method. For reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach