### PR TITLE
Use lodash.set to build form data with paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,37 @@ The following are FormView observables, thus emit "change" events:
 - `valid` - the valid state of the form
 - `data` - form field view values in `{ fieldName: value, fieldName2: value2 }` format
 
+## Verbose forms
+
+For verbose forms used to edit nested data, you can write field names as paths. Doing so, the `data` observable is nested according to the paths you specified so you can `set` or `save` this data to a state or collection more easily.
+
+### Example
+A form with a persons first and last name and an array of phone numbers, each of which has fields for *type* and *number*:
+
+```javascript
+var form = new FormView({
+  fields: [
+    new InputView({name: 'name.first', value: 'Michael'}),
+    new InputView({name: 'name.last', value: 'Mustermann'}),
+    new InputView({name: 'phone[0].type', value: 'home'}),
+    new InputView({name: 'phone[0].number', value: '1234567'}),
+    new InputView({name: 'phone[1].type', value: 'mobile'}),
+    new InputView({name: 'phone[1].number', value: '7654321'})
+  ]
+});
+
+console.log(form.data);
+// {
+//     name: {first: 'Michael', last: 'Mustermann'},
+//     phone: [
+//         {type: 'home', number: '1234567'},
+//         {type: 'mobile', number: '7654321'}
+//     ]
+// }
+```
+
+
+
 ## Special Events
 
 - `submit` - triggered when a form is submitted. Returns the `data` of the form as the only argument

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -1,5 +1,6 @@
 /*$AMPERSAND_VERSION*/
 var View = require('ampersand-view');
+var set = require('lodash.set');
 var isFunction = require('lodash.isfunction');
 var result = require('lodash.result');
 
@@ -15,7 +16,7 @@ module.exports = View.extend({
                 var res = {};
                 for (var key in this._fieldViews) {
                     if (this._fieldViews.hasOwnProperty(key)) {
-                        res[key] = this._fieldViews[key].value;
+                        set(res, key, this._fieldViews[key].value);
                     }
                 }
                 return this.clean(res);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "ampersand-version": "^1.0.0",
     "ampersand-view": "^8.0.0",
     "lodash.isfunction": "^3.0.2",
-    "lodash.result": "^3.0.0"
+    "lodash.result": "^3.0.0",
+    "lodash.set": "^3.7.4"
   },
   "devDependencies": {
     "ampersand-input-view": "^4.0.5",

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -110,6 +110,26 @@ test('autoappend', function(t) {
     t.end();
 });
 
+test('verbose data', function (t) {
+    var fields = [
+        new FakeField({name: 'name.first', value: 'Michael'}),
+        new FakeField({name: 'name.last', value: 'Mustermann'}),
+        new FakeField({name: 'phone[0].type', value: 'home'}),
+        new FakeField({name: 'phone[0].number', value: '1234567'}),
+        new FakeField({name: 'phone[1].type', value: 'mobile'}),
+        new FakeField({name: 'phone[1].number', value: '7654321'})
+    ];
+    var form = new FormView({ fields: fields });
+    t.same(form.data, {
+        name: {first: 'Michael', last: 'Mustermann'},
+        phone: [
+            {type: 'home', number: '1234567'},
+            {type: 'mobile', number: '7654321'}
+        ]
+    }, 'verbose data should be correctly parsed');
+    t.end();
+});
+
 test('clean', function(t) {
 	var field = new FakeField({
 		name: 'some_field',


### PR DESCRIPTION
In our project [invoiz](https://app.invoiz.de), we use a lot of verbose forms that have a variable number of inputs.

As an example, we've built an invoice form where an arbitrary number of positions can be added to the invoice. For every position added, multiple fields such as article name, article number, price, vat or discount are added to the invoice form.

Naming these similar, dynamic fields was a constant struggle.
Retrieving the form data in a format that would be easy to simply `.set()` or `.save()` on an associated model with submodels/subcollections required a lot of mapping.

With this pull request, i propose to build the derived `data` property of the `&-form-view` by using lodashs [set](https://lodash.com/docs#set) method to allow nested data structures as a result:

```javascript
var form = new FormView({
  fields: [
    new InputView({name: 'name.first', value: 'Michael'}),
    new InputView({name: 'name.last', value: 'Mustermann'}),
    new InputView({name: 'phone[0].type', value: 'home'}),
    new InputView({name: 'phone[0].number', value: '1234567'}),
    new InputView({name: 'phone[1].type', value: 'mobile'}),
    new InputView({name: 'phone[1].number', value: '7654321'})
  ]
});

console.log(form.data);
// {
//     name: {first: 'Michael', last: 'Mustermann'},
//     phone: [
//         {type: 'home', number: '1234567'},
//         {type: 'mobile', number: '7654321'}
//     ]
// }
```

We've used this way of naming fields and building data in production and it proved to be a considerable relief when dealing with complex forms.

This change would break backwards compatibility in case someone used array and object path notation (dots and brackets) in their field names before and would probably need a new major version bump and additional documentation (which i would certainly help with once i've gotten some reactions to the PR).