### PR TITLE
Fix 5.2.0 backwards compatibility issues

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -16,7 +16,11 @@ module.exports = View.extend({
                 var res = {};
                 for (var key in this._fieldViews) {
                     if (this._fieldViews.hasOwnProperty(key)) {
-                        set(res, key, this._fieldViews[key].value);
+                        if (key.match(/\[\]$/)) {
+                            res[key] = this._fieldViews[key].value;
+                        } else {
+                            set(res, key, this._fieldViews[key].value);
+                        }
                     }
                 }
                 return this.clean(res);

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -16,6 +16,8 @@ module.exports = View.extend({
                 var res = {};
                 for (var key in this._fieldViews) {
                     if (this._fieldViews.hasOwnProperty(key)) {
+                        // If field name ends with '[]', don't interpret
+                        // as verbose form field...
                         if (key.match(/\[\]$/)) {
                             res[key] = this._fieldViews[key].value;
                         } else {

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -130,22 +130,44 @@ test('verbose data', function (t) {
     t.end();
 });
 
+test('bracketed field names', function(t) {
+    var fields = [
+        new FakeField({name: 'foobars[]', value: [1,2,3,4]}),
+        new FakeField({name: 'name.first', value: 'Michael'}),
+        new FakeField({name: 'name.last', value: 'Mustermann'}),
+        new FakeField({name: 'phone[0].type', value: 'home'}),
+        new FakeField({name: 'phone[0].number', value: '1234567'}),
+        new FakeField({name: 'phone[1].type', value: 'mobile'}),
+        new FakeField({name: 'phone[1].number', value: '7654321'})
+    ];
+    var form = new FormView({ fields: fields });
+    t.same(form.data, {
+        'foobars[]': [1,2,3,4],
+        name: {first: 'Michael', last: 'Mustermann'},
+        phone: [
+            {type: 'home', number: '1234567'},
+            {type: 'mobile', number: '7654321'}
+        ]
+    }, 'verbose data should be correctly parsed while maintaining support for legacy field names ending in empty square brackets');
+    t.end();
+});
+
 test('clean', function(t) {
-	var field = new FakeField({
-		name: 'some_field',
-		value: '27'
-	});
-	var FormViewExtendedWithClean = FormView.extend({
-		clean: function(data) {
-			t.equal(data.some_field, field.value, 'data should have the raw value from the field');
-			data.some_field = Number(data.some_field);
-			return data;
-		}
-	});
-	var form = new FormViewExtendedWithClean({
-		fields: [ field ]
-	});
-	var data = form.data;
-	t.equal(data.some_field, Number(field.value), 'data should return cleaned data');
-	t.end();
+    var field = new FakeField({
+        name: 'some_field',
+        value: '27'
+    });
+    var FormViewExtendedWithClean = FormView.extend({
+        clean: function(data) {
+            t.equal(data.some_field, field.value, 'data should have the raw value from the field');
+            data.some_field = Number(data.some_field);
+            return data;
+        }
+    });
+    var form = new FormViewExtendedWithClean({
+        fields: [ field ]
+    });
+    var data = form.data;
+    t.equal(data.some_field, Number(field.value), 'data should return cleaned data');
+    t.end();
 });


### PR DESCRIPTION
Added some backward compatibility for forms with field names ending in empty square brackets. A lot of traditional (PHP) APIs use this syntax to denote a field with multiple values.

Fixes #55.

I'd suggest a 5.2.1 update.