### PR TITLE
Updated dependencies to survive get-object-path@0.0.2 being removed from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
   },
   "dependencies": {
     "ampersand-version": "^1.0.0",
-    "ampersand-view": "^8.0.0",
+    "ampersand-view": "^9.0.2",
     "lodash.isfunction": "^3.0.2",
-    "lodash.result": "^3.0.0",
-    "lodash.set": "^3.7.4"
+    "lodash.result": "^4.2.0",
+    "lodash.set": "^4.0.0"
   },
   "devDependencies": {
-    "ampersand-input-view": "^4.0.5",
     "ampersand-checkbox-view": "*",
-    "ampersand-model": "^5.0.3",
-    "browserify": "^10.2.4",
+    "ampersand-input-view": "^6.0.0",
+    "ampersand-model": "^6.0.3",
+    "browserify": "^13.0.0",
     "function-bind": "^1.0.2",
     "jshint": "^2.6.0",
-    "phantomjs": "^1.9.15",
+    "phantomjs-prebuilt": "^2.1.3",
     "precommit-hook": "^3.0.0",
     "tape": "^4.0.0",
     "zuul": "^3.9.0"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "ampersand-version": "^1.0.0",
     "ampersand-view": "^9.0.2",
     "lodash.isfunction": "^3.0.2",
-    "lodash.result": "^4.2.0",
-    "lodash.set": "^4.0.0"
+    "lodash.result": "^3.0.0",
+    "lodash.set": "^3.7.4"
   },
   "devDependencies": {
     "ampersand-checkbox-view": "*",


### PR DESCRIPTION
Also phantomjs appears to have been [renamed](https://github.com/Medium/phantomjs/issues/447) phantomjs-prebuilt so changed that too.