### PR TITLE
bump lodash to version to 4.11.1

### DIFF
--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -1,8 +1,8 @@
 /*$AMPERSAND_VERSION*/
 var View = require('ampersand-view');
-var set = require('lodash.set');
-var isFunction = require('lodash.isfunction');
-var result = require('lodash.result');
+var set = require('lodash/set');
+var isFunction = require('lodash/isFunction');
+var result = require('lodash/result');
 
 module.exports = View.extend({
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "dependencies": {
     "ampersand-version": "^1.0.0",
     "ampersand-view": "^9.0.2",
-    "lodash.isfunction": "^3.0.2",
-    "lodash.result": "^3.0.0",
-    "lodash.set": "^3.7.4"
+    "lodash": "^4.11.1"
   },
   "devDependencies": {
     "ampersand-checkbox-view": "*",


### PR DESCRIPTION
Didn't see a PR for this following the bump to lodash 4.11.1 in the other ampersand repositories.