### PR TITLE
Allow specifying fieldContainerEl in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,14 @@ Standard <a href="http://ampersandjs.com/learn/view-conventions">view convention
 * `fields` : array
     * Array of `FieldView`s.  If `autoAppend` is true, nodes defined by the view are built and appended to the end of the FormView.
 * `submitCallback` : function
-    * called on form submit
+    * Called on form submit
 * `validCallback` : function
-    *  this valid callback gets called (if it exists) when the form first loads and any time the form changes from valid to invalid or vice versa. You might use this to disable the "submit" button any time the form is invalid, for example.
+    * This valid callback gets called (if it exists) when the form first loads and any time the form changes from valid to invalid or vice versa. You might use this to disable the "submit" button any time the form is invalid, for example.
 * `clean` : function
-    * Let's you provide a function which will clean or modify what is returned by `getData` and passed to `submitCallback`.
+    * Lets you provide a function which will clean or modify what is returned by `getData` and passed to `submitCallback`.
+* `fieldContainerEl` : Element | string
+    * Container to append fields to (when `autoAppend` is `true`).
+    * This can either be a DOM element or a CSS selector string. If a string is passed, ampersand-view runs `this.query('YOUR STRING')` to try to find the element that should contain the fields. If you don't supply a `fieldContainerEl`, it will first try to find an element with the selector `'[data-hook~=field-container]'`. If no element for appending fields to is found, it will fallback to `this.el`.
 
 =======
 ## API Reference

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -34,6 +34,7 @@ module.exports = View.extend({
     initialize: function(opts) {
         opts = opts || {};
         this.el = opts.el;
+        this.fieldContainerEl = opts.fieldContainerEl;
         this.validCallback = opts.validCallback || this.validCallback;
         this.submitCallback = opts.submitCallback || this.submitCallback;
         this.clean = opts.clean || this.clean || function (res) { return res; };
@@ -168,7 +169,7 @@ module.exports = View.extend({
             this.el = document.createElement('form');
         }
         if (this.autoAppend) {
-            this.fieldContainerEl = this.el.querySelector('[data-hook~=field-container]') || this.el;
+            this.fieldContainerEl = this.fieldContainerEl || this.el.querySelector('[data-hook~=field-container]') || this.el;
         }
         this._fieldViewsArray.forEach(function renderEachField(fV) {
             this.renderField(fV, true);

--- a/ampersand-form-view.js
+++ b/ampersand-form-view.js
@@ -169,7 +169,7 @@ module.exports = View.extend({
             this.el = document.createElement('form');
         }
         if (this.autoAppend) {
-            this.fieldContainerEl = this.fieldContainerEl || this.el.querySelector('[data-hook~=field-container]') || this.el;
+            this.fieldContainerEl = this.query(this.fieldContainerEl || '[data-hook~=field-container]') || this.el;
         }
         this._fieldViewsArray.forEach(function renderEachField(fV) {
             this.renderField(fV, true);

--- a/test/basic.js
+++ b/test/basic.js
@@ -43,12 +43,13 @@ var getView = function (opts) {
 
     // Create a View with a nested FormView.
     var View = AmpersandView.extend({
-        template: '<form data-hook="test-form"></form>',
+        template: opts.template || '<form data-hook="test-form"></form>',
         render: function () {
             this.renderWithTemplate();
             this.form = new FormView({
                 autoRender: formOpts.autoRender,
                 autoAppend: formOpts.autoAppend,
+                fieldContainerEl: formOpts.fieldContainerEl,
                 el: this.queryByHook('test-form'),
                 model: this.model,
                 values: {
@@ -168,3 +169,39 @@ test('autoAppend === false', function(t) {
 
     t.end();
 });
+
+test('default fieldContainerEl', function(t) {
+    var view = getView({
+        form: {
+            autoRender: true
+        },
+        template: '<form data-hook="test-form"><div data-hook="field-container"></div></form>'
+    });
+
+    var fieldContainer = view.form.queryByHook('field-container');
+
+    t.equal(view.form.el.children.length, 1);
+    t.ok(fieldContainer);
+    t.equal(fieldContainer.children.length, 3);
+
+    t.end();
+});
+
+test('custom fieldContainerEl', function(t) {
+    var view = getView({
+        form: {
+            autoRender: true,
+            fieldContainerEl: '[data-hook=foobar-container]'
+        },
+        template: '<form data-hook="test-form"><div data-hook="foobar-container"></div></form>'
+    });
+
+    var fieldContainer = view.form.queryByHook('foobar-container');
+
+    t.equal(view.form.el.children.length, 1);
+    t.ok(fieldContainer);
+    t.equal(fieldContainer.children.length, 3);
+
+    t.end();
+});
+

--- a/test/basic.js
+++ b/test/basic.js
@@ -48,6 +48,7 @@ var getView = function (opts) {
             this.renderWithTemplate();
             this.form = new FormView({
                 autoRender: formOpts.autoRender,
+                autoAppend: formOpts.autoAppend,
                 el: this.queryByHook('test-form'),
                 model: this.model,
                 values: {
@@ -151,5 +152,19 @@ test('field value setter/getter', function(t) {
     t.equal(view.form.getValue('textarea'), 'Original value', 'getValue() extracts value from provided field');
     view.form.setValue('textarea', 'newValue');
     t.equal(view.form.getValue('textarea'), 'newValue', 'setValue() sets value on provided field');
+    t.end();
+});
+
+test('autoAppend === false', function(t) {
+    var view = getView({ form: { autoRender: true, autoAppend: false }});
+
+    t.equal(view.form.el.children.length, 0);
+
+    t.ok(view.form._fieldViewsArray.length, 3);
+
+    view.form._fieldViewsArray.every(function(field) {
+        t.ok(field.rendered);
+    });
+
     t.end();
 });

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -106,10 +106,6 @@ test('on change:valid', function(t) {
     field.setValid(true);
 });
 
-test('autoappend', function(t) {
-    t.end();
-});
-
 test('verbose data', function (t) {
     var fields = [
         new FakeField({name: 'name.first', value: 'Michael'}),


### PR DESCRIPTION
Allows specifying `fieldContainerEl` in options to use for appending fields to.

Minor change.

Todo:
- [x] documentation
- [x] tests